### PR TITLE
feat: Add SQLite backend with SQLAlchemy and Flask

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,22 @@
+# Python
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+*.env
+env/
+venv/
+*.egg-info/
+dist/
+build/
+
+# SQLite Database
+app.db
+*.sqlite
+*.sqlite3
+
+# IDE / Editor specific
+.vscode/
+.idea/
+*.swp
+*.swo

--- a/=0.8.1
+++ b/=0.8.1
@@ -1,0 +1,23 @@
+Collecting Flask-Testing
+  Downloading Flask-Testing-0.8.1.tar.gz (45 kB)
+  Installing build dependencies: started
+  Installing build dependencies: finished with status 'done'
+  Getting requirements to build wheel: started
+  Getting requirements to build wheel: finished with status 'done'
+  Preparing metadata (pyproject.toml): started
+  Preparing metadata (pyproject.toml): finished with status 'done'
+Requirement already satisfied: Flask in /home/jules/.pyenv/versions/3.12.11/lib/python3.12/site-packages (from Flask-Testing) (3.1.1)
+Requirement already satisfied: blinker>=1.9.0 in /home/jules/.pyenv/versions/3.12.11/lib/python3.12/site-packages (from Flask->Flask-Testing) (1.9.0)
+Requirement already satisfied: click>=8.1.3 in /home/jules/.pyenv/versions/3.12.11/lib/python3.12/site-packages (from Flask->Flask-Testing) (8.2.1)
+Requirement already satisfied: itsdangerous>=2.2.0 in /home/jules/.pyenv/versions/3.12.11/lib/python3.12/site-packages (from Flask->Flask-Testing) (2.2.0)
+Requirement already satisfied: jinja2>=3.1.2 in /home/jules/.pyenv/versions/3.12.11/lib/python3.12/site-packages (from Flask->Flask-Testing) (3.1.6)
+Requirement already satisfied: markupsafe>=2.1.1 in /home/jules/.pyenv/versions/3.12.11/lib/python3.12/site-packages (from Flask->Flask-Testing) (3.0.2)
+Requirement already satisfied: werkzeug>=3.1.0 in /home/jules/.pyenv/versions/3.12.11/lib/python3.12/site-packages (from Flask->Flask-Testing) (3.1.3)
+Building wheels for collected packages: Flask-Testing
+  Building wheel for Flask-Testing (pyproject.toml): started
+  Building wheel for Flask-Testing (pyproject.toml): finished with status 'done'
+  Created wheel for Flask-Testing: filename=flask_testing-0.8.1-py3-none-any.whl size=8268 sha256=a73d7d5ed727263a33ab2a8ddd0d2b6f13c8b0792e4b4efa09b1a9f7c0fd75e2
+  Stored in directory: /home/jules/.cache/pip/wheels/cb/e8/a7/362cc4dc172b8146cf13c1b810d6824aa04968afa518c7f352
+Successfully built Flask-Testing
+Installing collected packages: Flask-Testing
+Successfully installed Flask-Testing-0.8.1

--- a/=3.2
+++ b/=3.2
@@ -1,0 +1,5 @@
+Collecting bcrypt
+  Downloading bcrypt-4.3.0-cp39-abi3-manylinux_2_34_x86_64.whl.metadata (10 kB)
+Downloading bcrypt-4.3.0-cp39-abi3-manylinux_2_34_x86_64.whl (284 kB)
+Installing collected packages: bcrypt
+Successfully installed bcrypt-4.3.0

--- a/README.md
+++ b/README.md
@@ -1,2 +1,70 @@
 # JulesCommunity
 A website for Jules Community. Contain Jules Updates, Prompts, Projects, Docs and much more.
+
+## Backend API with SQLite Database
+
+This project now includes a Python-based backend API using Flask and SQLAlchemy to interact with an SQLite database. The database stores information about users, products, and application settings.
+
+### Project Structure
+
+- `app.py`: The main Flask application file with API endpoints.
+- `models.py`: Contains SQLAlchemy database models and session management.
+- `init_db.py`: A script to initialize the database and create tables (and optionally add sample data).
+- `requirements.txt`: Python dependencies.
+- `app.db`: The SQLite database file (will be created when `init_db.py` or `app.py` is run).
+
+### Setup and Usage
+
+#### 1. Prerequisites
+- Python 3.x
+- pip (Python package installer)
+
+#### 2. Install Dependencies
+Navigate to the project root directory in your terminal and run:
+```bash
+pip install -r requirements.txt
+```
+
+#### 3. Initialize the Database
+Before running the application for the first time, or if you want to reset the database with sample data, run the initialization script:
+```bash
+python init_db.py
+```
+This will create an `app.db` file in the project root and set up the necessary tables. It will also populate some sample data for products and application settings.
+
+#### 4. Run the Flask Application
+To start the development server:
+```bash
+python app.py
+```
+The application will typically be available at `http://127.0.0.1:5000/`.
+
+### API Endpoints
+
+Here are some of the available API endpoints:
+
+**Users**
+- `POST /users`: Create a new user.
+  - **Body (JSON):** `{"username": "testuser", "email": "test@example.com", "password": "securepassword123"}`
+  - **Success Response (201):** `{"message": "User created", "user_id": 1, "username": "testuser"}`
+- `GET /users/<user_id>`: Retrieve a user by their ID.
+  - **Success Response (200):** `{"id": 1, "username": "testuser", "email": "test@example.com", "created_at": "..."}`
+
+**Products**
+- `POST /products`: Add a new product.
+  - **Body (JSON):** `{"name": "Awesome Gadget", "description": "The best gadget ever.", "price": 49.99, "sku": "AG001", "stock_quantity": 100}`
+  - **Success Response (201):** `{"message": "Product added", "product_id": 1}`
+- `GET /products`: List all products.
+  - **Success Response (200):** `[{"id": 1, "name": "Laptop Pro", ...}, ...]`
+
+**Application Settings**
+- `POST /settings`: Create or update an application setting.
+  - **Body (JSON):** `{"key": "site_title", "value": "My Jules App", "description": "The main title for the website"}`
+  - **Success Response (200/201):** `{"message": "Setting created/updated", "setting": {"key": "site_title", "value": "My Jules App"}}`
+- `GET /settings/<key>`: Retrieve an application setting by its key.
+  - **Success Response (200):** `{"key": "site_title", "value": "My Jules App", "description": "..."}`
+
+### Notes
+- The SQLite database file (`app.db`) will be created in the root of the project. It's advisable to add `app.db` to your `.gitignore` file if you don't want to commit the actual database contents.
+- For production environments, use a proper WSGI server (like Gunicorn or uWSGI) instead of Flask's built-in development server.
+- Password hashing is implemented using `bcrypt`.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,164 @@
+from flask import Flask, request, jsonify
+from sqlalchemy.orm import Session
+from sqlalchemy.exc import IntegrityError
+import bcrypt # Added for password hashing
+
+# It's good practice to have models and db session management in separate files
+from models import User, Product, ApplicationSetting, SessionLocal, engine, Base, get_db
+
+# Create tables if they don't exist (alternative to running init_db.py separately for simple cases)
+# Base.metadata.create_all(bind=engine)
+
+app = Flask(__name__)
+
+# Dependency for database session
+def get_db_session():
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+@app.route("/")
+def hello():
+    return "Hello! Your Flask app with SQLAlchemy is running. Use specific endpoints to interact with the database."
+
+# --- User Routes ---
+@app.route('/users', methods=['POST'])
+def create_user():
+    data = request.get_json()
+    if not data or not data.get('username') or not data.get('email') or not data.get('password'):
+        return jsonify({"error": "Missing username, email, or password"}), 400
+
+    db: Session = next(get_db_session())
+    try:
+        # Hash the password
+        hashed_password = bcrypt.hashpw(data['password'].encode('utf-8'), bcrypt.gensalt()).decode('utf-8')
+
+        new_user = User(
+            username=data['username'],
+            email=data['email'],
+            password_hash=hashed_password # Store the hashed password
+        )
+        db.add(new_user)
+        db.commit()
+        db.refresh(new_user)
+        return jsonify({"message": "User created", "user_id": new_user.id, "username": new_user.username}), 201
+    except IntegrityError: # Handles unique constraint violations (e.g., username or email already exists)
+        db.rollback()
+        return jsonify({"error": "Username or email already exists"}), 409
+    except Exception as e:
+        db.rollback()
+        return jsonify({"error": str(e)}), 500
+    finally:
+        db.close()
+
+@app.route('/users/<int:user_id>', methods=['GET'])
+def get_user(user_id):
+    db: Session = next(get_db_session())
+    try:
+        user = db.query(User).filter(User.id == user_id).first()
+        if user:
+            return jsonify({
+                "id": user.id,
+                "username": user.username,
+                "email": user.email,
+                "created_at": user.created_at.isoformat()
+            })
+        return jsonify({"error": "User not found"}), 404
+    finally:
+        db.close()
+
+# --- Product Routes ---
+@app.route('/products', methods=['POST'])
+def add_product():
+    data = request.get_json()
+    if not data or not data.get('name') or data.get('price') is None: # price can be 0
+        return jsonify({"error": "Missing product name or price"}), 400
+
+    db: Session = next(get_db_session())
+    try:
+        new_product = Product(
+            name=data['name'],
+            description=data.get('description'),
+            price=data['price'],
+            sku=data.get('sku'),
+            stock_quantity=data.get('stock_quantity', 0)
+        )
+        db.add(new_product)
+        db.commit()
+        db.refresh(new_product)
+        return jsonify({"message": "Product added", "product_id": new_product.id}), 201
+    except IntegrityError:
+        db.rollback()
+        return jsonify({"error": "Product SKU already exists"}), 409
+    except Exception as e:
+        db.rollback()
+        return jsonify({"error": str(e)}), 500
+    finally:
+        db.close()
+
+@app.route('/products', methods=['GET'])
+def list_products():
+    db: Session = next(get_db_session())
+    try:
+        products = db.query(Product).all()
+        return jsonify([{
+            "id": p.id, "name": p.name, "description": p.description,
+            "price": str(p.price), "sku": p.sku, "stock_quantity": p.stock_quantity
+        } for p in products])
+    finally:
+        db.close()
+
+# --- Application Settings Routes ---
+@app.route('/settings/<string:key>', methods=['GET'])
+def get_setting(key):
+    db: Session = next(get_db_session())
+    try:
+        setting = db.query(ApplicationSetting).filter(ApplicationSetting.key == key).first()
+        if setting:
+            return jsonify({"key": setting.key, "value": setting.value, "description": setting.description})
+        return jsonify({"error": "Setting not found"}), 404
+    finally:
+        db.close()
+
+@app.route('/settings', methods=['POST'])
+def create_or_update_setting():
+    data = request.get_json()
+    if not data or not data.get('key'):
+        return jsonify({"error": "Missing setting key"}), 400
+
+    db: Session = next(get_db_session())
+    try:
+        setting = db.query(ApplicationSetting).filter(ApplicationSetting.key == data['key']).first()
+        if setting: # Update existing setting
+            setting.value = data.get('value')
+            setting.description = data.get('description', setting.description)
+            message = "Setting updated"
+        else: # Create new setting
+            setting = ApplicationSetting(
+                key=data['key'],
+                value=data.get('value'),
+                description=data.get('description')
+            )
+            db.add(setting)
+            message = "Setting created"
+
+        db.commit()
+        db.refresh(setting)
+        return jsonify({"message": message, "setting": {"key": setting.key, "value": setting.value}}), 200 if message == "Setting updated" else 201
+    except Exception as e:
+        db.rollback()
+        return jsonify({"error": str(e)}), 500
+    finally:
+        db.close()
+
+
+if __name__ == '__main__':
+    # For development server. In production, use a WSGI server like Gunicorn.
+    # Make sure to run init_db.py first if you haven't or tables don't exist.
+    print("Attempting to create database tables if they don't exist (via app.py)...")
+    Base.metadata.create_all(bind=engine) # Ensures tables are created when app starts
+    print("Tables checked/created.")
+    print("To initialize with sample data, run: python init_db.py")
+    app.run(debug=True)

--- a/init_db.py
+++ b/init_db.py
@@ -1,0 +1,52 @@
+from models import create_tables, engine, SessionLocal, User, ApplicationSetting, Product
+
+def initialize_database():
+    print("Initializing database...")
+    # Create all tables
+    create_tables()
+    print("Tables created successfully (if they didn't already exist).")
+
+    # Optional: Add some initial data for demonstration
+    db = SessionLocal()
+    try:
+        # Check if settings already exist to avoid duplicates if script is run multiple times
+        if db.query(ApplicationSetting).count() == 0:
+            print("Adding initial application settings...")
+            default_settings = [
+                ApplicationSetting(key="site_name", value="My Awesome App", description="The public name of the application."),
+                ApplicationSetting(key="maintenance_mode", value="false", description="Set to 'true' to enable maintenance mode."),
+                ApplicationSetting(key="admin_email", value="admin@example.com", description="Default admin contact email.")
+            ]
+            db.add_all(default_settings)
+            db.commit()
+            print("Initial application settings added.")
+        else:
+            print("Application settings already exist, skipping initial data.")
+
+        # Check if products already exist
+        if db.query(Product).count() == 0:
+            print("Adding initial sample products...")
+            sample_products = [
+                Product(name="Laptop Pro", description="High-performance laptop for professionals.", price=1200.00, sku="LP1001", stock_quantity=50),
+                Product(name="Wireless Mouse", description="Ergonomic wireless mouse.", price=25.50, sku="WM2002", stock_quantity=200),
+                Product(name="Mechanical Keyboard", description="RGB Mechanical Keyboard with blue switches.", price=75.00, sku="MK3003", stock_quantity=100)
+            ]
+            db.add_all(sample_products)
+            db.commit()
+            print("Initial sample products added.")
+        else:
+            print("Products already exist, skipping initial data.")
+
+        # Note: Adding initial users should be handled carefully, especially regarding passwords.
+        # For now, we'll skip adding a default user here, as password hashing should be part of user creation logic in the app.
+
+    except Exception as e:
+        print(f"An error occurred during initial data population: {e}")
+        db.rollback()
+    finally:
+        db.close()
+
+    print("Database initialization complete.")
+
+if __name__ == "__main__":
+    initialize_database()

--- a/models.py
+++ b/models.py
@@ -1,0 +1,67 @@
+import datetime
+
+from sqlalchemy import create_engine, Column, Integer, String, Text, DateTime, Numeric, UniqueConstraint
+from sqlalchemy.orm import sessionmaker, declarative_base
+from sqlalchemy.sql import func
+
+DATABASE_URL = "sqlite:///./app.db"
+
+engine = create_engine(DATABASE_URL, connect_args={"check_same_thread": False}) # check_same_thread for SQLite with Flask
+SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+Base = declarative_base()
+
+class User(Base):
+    __tablename__ = "users"
+
+    id = Column(Integer, primary_key=True, index=True, autoincrement=True)
+    username = Column(String, unique=True, index=True, nullable=False)
+    email = Column(String, unique=True, index=True, nullable=False)
+    password_hash = Column(String, nullable=False)
+    created_at = Column(DateTime(timezone=True), server_default=func.now())
+    updated_at = Column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now())
+
+    __table_args__ = (UniqueConstraint('username'), UniqueConstraint('email'),)
+
+class ApplicationSetting(Base):
+    __tablename__ = "application_settings"
+
+    id = Column(Integer, primary_key=True, index=True, autoincrement=True)
+    key = Column(String, unique=True, index=True, nullable=False)
+    value = Column(Text, nullable=True)
+    description = Column(Text, nullable=True)
+    created_at = Column(DateTime(timezone=True), server_default=func.now())
+    updated_at = Column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now())
+
+    __table_args__ = (UniqueConstraint('key'),)
+
+class Product(Base):
+    __tablename__ = "products"
+
+    id = Column(Integer, primary_key=True, index=True, autoincrement=True)
+    name = Column(String, nullable=False, index=True)
+    description = Column(Text, nullable=True)
+    price = Column(Numeric(10, 2), nullable=False) # Example: 10 digits in total, 2 after decimal point
+    sku = Column(String, unique=True, index=True, nullable=True)
+    stock_quantity = Column(Integer, default=0, nullable=False)
+    created_at = Column(DateTime(timezone=True), server_default=func.now())
+    updated_at = Column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now())
+
+    __table_args__ = (UniqueConstraint('sku'),)
+
+def get_db():
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+# Utility to create tables (can be called from init_db.py)
+def create_tables():
+    Base.metadata.create_all(bind=engine)
+
+if __name__ == "__main__":
+    # This part is for demonstration or direct execution,
+    # normally table creation would be handled by a migration tool or a dedicated script.
+    print("Creating database tables...")
+    create_tables()
+    print("Database tables created (if they didn't exist).")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+SQLAlchemy>=1.4
+Flask>=2.0
+bcrypt>=3.2
+Flask-Testing>=0.8.1

--- a/test_app.py
+++ b/test_app.py
@@ -1,0 +1,204 @@
+import unittest
+import json
+import os
+
+# Import models module for early patching
+import models as models_module
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+# --- Start of Global Patching ---
+# This code runs when test_app.py is imported.
+# It patches models.py *before* app.py (and its routes) are imported later in this file.
+
+TEST_DB_FILE = 'test_app.db' # Define a global for the test database filename
+
+# Create a new engine instance for the test database.
+_test_engine = create_engine(
+    f'sqlite:///{TEST_DB_FILE}',
+    connect_args={"check_same_thread": False}
+)
+
+# Directly modify the engine and SessionLocal in the imported models_module.
+# Any subsequent import of 'engine' or 'SessionLocal' from 'models' by other modules
+# (like app.py) will get these patched versions.
+models_module.engine = _test_engine
+models_module.SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=_test_engine)
+
+# Ensure that the Base metadata in models_module is bound to this test_engine.
+# This is crucial for Base.metadata.create_all() to work on the correct database.
+models_module.Base.metadata.bind = _test_engine
+
+# Create all tables in the test database immediately after patching.
+# This ensures tables exist before any app code (like route handlers) tries to access them.
+models_module.Base.metadata.create_all(bind=_test_engine)
+# --- End of Global Patching ---
+
+# Now, import the Flask app. It will see the patched models_module.
+from app import app
+# Import specific model classes for use in assertions, now that models_module is patched.
+from models import User, Product, ApplicationSetting
+
+# Configure the app for testing (already done by global patching for DB)
+app.config['TESTING'] = True
+
+
+class AppTestCase(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        """Set up for all tests once. Tables are already created by global patching."""
+        cls.test_db_file = TEST_DB_FILE  # Use the global test DB filename
+        cls.test_engine = models_module.engine # Use the globally patched engine
+
+        # Optional: Populate any truly global test data once here, if needed.
+        # session = models_module.SessionLocal()
+        # try:
+        #     # Example: if not session.query(models_module.SomeGlobalSetting).first(): ...
+        #     session.commit()
+        # finally:
+        #     session.close()
+
+    @classmethod
+    def tearDownClass(cls):
+        """Tear down after all tests once."""
+        # Drop all tables from the test database
+        models_module.Base.metadata.drop_all(bind=cls.test_engine)
+        # Remove the test database file
+        if os.path.exists(cls.test_db_file):
+            os.remove(cls.test_db_file)
+
+    def setUp(self):
+        """Set up for each test method."""
+        self.app = app.test_client()
+        # Use the globally patched SessionLocal from models_module
+        self.SessionLocal = models_module.SessionLocal
+
+        # Clean data from tables before each test to ensure test isolation
+        session = self.SessionLocal()
+        try:
+            session.query(User).delete() # User from models, now correctly mapped
+            session.query(Product).delete()
+            session.query(ApplicationSetting).delete()
+            session.commit()
+
+            # If specific tests need specific pre-existing data, add it here.
+            # This makes tests more self-contained.
+            if self._testMethodName == 'test_07_get_setting':
+                setting = ApplicationSetting(key="site_name", value="Test Site for test_07", description="...")
+                session.add(setting)
+                session.commit()
+
+            if self._testMethodName == 'test_09_update_setting':
+                 # Ensure the setting to be updated exists for this test
+                setting = ApplicationSetting(key='update_setting_key', value='initial_value_for_09', description='Setting to be updated')
+                session.add(setting)
+                session.commit()
+
+        except Exception as e:
+            session.rollback()
+            print(f"Error in setUp (cleaning/populating data): {e}")
+        finally:
+            session.close()
+
+
+    def test_01_home_page(self):
+        """Test the home page"""
+        response = self.app.get('/')
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(b"Hello! Your Flask app with SQLAlchemy is running.", response.data)
+
+    def test_02_create_user(self):
+        """Test creating a new user"""
+        response = self.app.post('/users',
+                                 data=json.dumps(dict(username='testuser1', email='test1@example.com', password='password123')),
+                                 content_type='application/json')
+        self.assertEqual(response.status_code, 201, response.data.decode())
+        data = json.loads(response.data)
+        self.assertEqual(data['username'], 'testuser1')
+        self.assertIn('user_id', data)
+
+
+    def test_03_create_user_duplicate_username(self):
+        """Test creating a user with a duplicate username"""
+        # First user
+        self.app.post('/users',
+                      data=json.dumps(dict(username='testuser2', email='test2@example.com', password='password123')),
+                      content_type='application/json')
+        # Attempt to create another user with the same username
+        response = self.app.post('/users',
+                                 data=json.dumps(dict(username='testuser2', email='test3@example.com', password='password456')),
+                                 content_type='application/json')
+        self.assertEqual(response.status_code, 409, response.data.decode())
+
+    def test_04_get_user(self):
+        """Test getting a user by ID"""
+        # Create a user first
+        post_response = self.app.post('/users',
+                                      data=json.dumps(dict(username='testuser4', email='test4@example.com', password='password123')),
+                                      content_type='application/json')
+        self.assertEqual(post_response.status_code, 201, f"Failed to create user for get_user test: {post_response.data.decode()}")
+        user_id = json.loads(post_response.data)['user_id']
+
+        # Get the user
+        response = self.app.get(f'/users/{user_id}')
+        self.assertEqual(response.status_code, 200, response.data.decode())
+        data = json.loads(response.data)
+        self.assertEqual(data['username'], 'testuser4')
+
+    def test_05_add_product(self):
+        """Test adding a new product"""
+        response = self.app.post('/products',
+                                 data=json.dumps(dict(name='Test Product', price=10.99, sku='TP001')),
+                                 content_type='application/json')
+        self.assertEqual(response.status_code, 201, response.data.decode())
+        data = json.loads(response.data)
+        self.assertIn('product_id', data)
+
+    def test_06_list_products(self):
+        """Test listing all products"""
+        # Add a product first
+        add_prod_response = self.app.post('/products',
+                      data=json.dumps(dict(name='Test Product 2', price=19.99, sku='TP002')),
+                      content_type='application/json')
+        self.assertEqual(add_prod_response.status_code, 201, f"Failed to add product for list_products test: {add_prod_response.data.decode()}")
+
+        response = self.app.get('/products')
+        self.assertEqual(response.status_code, 200, response.data.decode())
+        data = json.loads(response.data)
+        self.assertIsInstance(data, list)
+        self.assertTrue(any(p['sku'] == 'TP002' for p in data), "Added product not found in list")
+
+
+    def test_07_get_setting(self):
+        """Test getting an application setting (created in setUp for this test)"""
+        response = self.app.get('/settings/site_name') # site_name is added in setUp for this test
+        self.assertEqual(response.status_code, 200, response.data.decode())
+        data = json.loads(response.data)
+        self.assertEqual(data['key'], 'site_name')
+        self.assertEqual(data['value'], 'Test Site for test_07')
+
+    def test_08_create_setting(self):
+        """Test creating a new application setting"""
+        response = self.app.post('/settings',
+                                 data=json.dumps(dict(key='new_setting', value='new_value', description='A new test setting')),
+                                 content_type='application/json')
+        self.assertEqual(response.status_code, 201, response.data.decode())
+        data = json.loads(response.data)
+        self.assertEqual(data['setting']['key'], 'new_setting')
+        self.assertEqual(data['setting']['value'], 'new_value')
+
+    def test_09_update_setting(self):
+        """Test updating an existing application setting (created in setUp for this test)"""
+        key_to_update = 'update_setting_key' # This key is added in setUp for this test.
+
+        # Now, update it
+        response = self.app.post('/settings',
+                                 data=json.dumps(dict(key=key_to_update, value='updated_value')),
+                                 content_type='application/json')
+        self.assertEqual(response.status_code, 200, response.data.decode())
+        data = json.loads(response.data)
+        self.assertEqual(data['setting']['value'], 'updated_value')
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
- Implemented a basic Flask backend with SQLAlchemy for database interaction.
- Added models for Users, Products, and ApplicationSettings.
- Included an initialization script (init_db.py) for database setup and seeding.
- Provided API endpoints for basic CRUD operations on the models.
- Updated README with setup instructions and API usage.
- Added .gitignore to exclude database file and Python caches.
- Implemented unit tests for the Flask application and database operations.