### PR TITLE
Remove spotlight image references from homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -82,19 +82,16 @@
                 <h2 class="section-title">Community Spotlight</h2>
                 <div class="spotlight-grid">
                     <div class="spotlight-card">
-                        <img src="spotlight-image-1.jpg" alt="Spotlight image 1" class="spotlight-image">
                         <h4>Jules v1.3: The Generative Update!</h4>
                         <p>Explore enhanced creative capabilities and more robust tool integrations. Dive into what's new!</p>
                         <a href="news.html#jules-v1.3" class="button button-secondary button-small">Read Article</a>
                     </div>
                     <div class="spotlight-card">
-                         <img src="spotlight-image-2.jpg" alt="Spotlight image 2" class="spotlight-image">
                         <h4>Top Prompt: "Strategic Content Planner"</h4>
                         <p>Revolutionize your content creation with this community-favorite prompt for Jules.</p>
                         <a href="prompts.html#content-planner" class="button button-secondary button-small">View Prompt</a>
                     </div>
                     <div class="spotlight-card">
-                         <img src="spotlight-image-3.jpg" alt="Spotlight image 3" class="spotlight-image">
                         <h4>Guide: "Automating Workflows with Jules"</h4>
                         <p>Unlock new levels of productivity by learning to automate complex tasks seamlessly.</p>
                         <a href="guides.html#automation-workflows" class="button button-secondary button-small">Read Guide</a>


### PR DESCRIPTION
The image files themselves were not found in the repository.