### PR TITLE
Fix: Add Flask-Migrate to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ SQLAlchemy>=1.4
 Flask>=2.0
 bcrypt>=3.2
 Flask-Testing>=0.8.1
+Flask-Migrate>=3.0


### PR DESCRIPTION
Flask-Migrate was imported in app.py but missing from requirements.txt, causing the application to fail at startup.

This change adds Flask-Migrate to the dependencies, allowing the server to start correctly.