### PR TITLE
feat: Remove "Feedback" from navigation bar

### DIFF
--- a/templates/changelog.html
+++ b/templates/changelog.html
@@ -22,7 +22,6 @@
                     <li><a href="changelog.html" class="active">Changelog</a></li>
                     <li><a href="guides.html" title="Details coming soon">Guides <small style="font-size: 0.7em; color: var(--text-light);">(Soon)</small></a></li>
                     <li><a href="showcase.html" title="Details coming soon">Projects <small style="font-size: 0.7em; color: var(--text-light);">(Soon)</small></a></li>
-                    <li><a href="feedback.html">Feedback</a></li>
                 </ul>
             </nav>
             <a href="guides.html" class="button button-primary nav-cta-button desktop-only">Get Started</a>

--- a/templates/docs.html
+++ b/templates/docs.html
@@ -22,7 +22,6 @@
                     <li><a href="changelog.html">Changelog</a></li>
                     <li><a href="guides.html" title="Details coming soon">Guides <small style="font-size: 0.7em; color: var(--text-light);">(Soon)</small></a></li>
                     <li><a href="showcase.html" title="Details coming soon">Projects <small style="font-size: 0.7em; color: var(--text-light);">(Soon)</small></a></li>
-                    <li><a href="feedback.html">Feedback</a></li>
                 </ul>
             </nav>
             <a href="guides.html" class="button button-primary nav-cta-button desktop-only">Get Started</a>

--- a/templates/guides.html
+++ b/templates/guides.html
@@ -22,7 +22,6 @@
                     <li><a href="changelog.html">Changelog</a></li>
                     <li><a href="guides.html" class="active">Guides <small style="font-size: 0.7em; color: var(--text-light);">(Soon)</small></a></li>
                     <li><a href="showcase.html" title="Details coming soon">Projects <small style="font-size: 0.7em; color: var(--text-light);">(Soon)</small></a></li>
-                    <li><a href="feedback.html">Feedback</a></li>
                 </ul>
             </nav>
             <a href="docs.html" class="button button-primary nav-cta-button desktop-only">Get Started</a>

--- a/templates/index.html
+++ b/templates/index.html
@@ -23,7 +23,6 @@
                     <li><a href="changelog.html">Changelog</a></li>
                     <li><a href="guides.html" title="Details coming soon">Guides <small style="font-size: 0.7em; color: var(--text-light);">(Soon)</small></a></li>
                     <li><a href="showcase.html" title="Details coming soon">Projects <small style="font-size: 0.7em; color: var(--text-light);">(Soon)</small></a></li>
-                    <li><a href="feedback.html">Feedback</a></li>
                 </ul>
             </nav>
             <a href="docs.html" class="button button-primary nav-cta-button desktop-only">Get Started</a>

--- a/templates/integrations.html
+++ b/templates/integrations.html
@@ -22,7 +22,6 @@
                     <li><a href="guides.html">Guides</a></li>
                     <li><a href="showcase.html">Projects</a></li>
                     <li><a href="integrations.html" class="active">Integrations</a></li>
-                    <li><a href="feedback.html">Feedback</a></li>
                     <li class="mobile-only"><a href="guides.html" class="button button-primary">Get Started</a></li>
                 </ul>
             </nav>

--- a/templates/news.html
+++ b/templates/news.html
@@ -22,7 +22,6 @@
                     <li><a href="guides.html">Guides</a></li>
                     <li><a href="showcase.html">Projects</a></li>
                     <li><a href="integrations.html">Integrations</a></li>
-                    <li><a href="feedback.html">Feedback</a></li>
                     <li class="mobile-only"><a href="guides.html" class="button button-primary">Get Started</a></li>
                 </ul>
             </nav>

--- a/templates/prompts.html
+++ b/templates/prompts.html
@@ -22,7 +22,6 @@
                     <li><a href="guides.html">Guides</a></li>
                     <li><a href="showcase.html">Showcase</a></li>
                     <li><a href="integrations.html">Integrations</a></li>
-                    <li><a href="feedback.html">Feedback</a></li>
                     <li class="mobile-only"><a href="guides.html" class="button button-primary">Get Started</a></li>
                 </ul>
             </nav>

--- a/templates/showcase.html
+++ b/templates/showcase.html
@@ -22,7 +22,6 @@
                     <li><a href="changelog.html">Changelog</a></li>
                     <li><a href="guides.html" title="Details coming soon">Guides <small style="font-size: 0.7em; color: var(--text-light);">(Soon)</small></a></li>
                     <li><a href="showcase.html" class="active">Projects <small style="font-size: 0.7em; color: var(--text-light);">(Soon)</small></a></li>
-                    <li><a href="feedback.html">Feedback</a></li>
                 </ul>
             </nav>
             <a href="docs.html" class="button button-primary nav-cta-button desktop-only">Get Started</a>


### PR DESCRIPTION
Removes the "Feedback" link from the main navigation bar across all pages. The navigation bar is duplicated in multiple template files, so the change is applied to each file.