### PR TITLE
Restore NYC subway hero animation

### DIFF
--- a/3d-engine.js
+++ b/3d-engine.js
@@ -8,26 +8,38 @@ class JulesSubwayScene {
         this.renderer = null;
         this.scene = null;
         this.camera = null;
-        this.renderer = null;
-        this.canvas = null;
-        this.animationId = null;
-        this.particles = [];
-        this.subwayLines = [];
-        this.subwayTrain = null;
-        this.subwayStations = [];
-        this.trackCurve = null;
-        this.trackPoints = [];
-        this.mapElevation = -20;
-        this.trainProgress = 0;
-        this.trainSpeed = 0.0006;
-        this.lastArrivedStationIndex = null;
+        this.clock = null;
+
+        this.mapElevation = -18;
         this.mapGroup = new THREE.Group();
-        this.cameraBasePosition = { y: 220, z: 360 };
-        this.cameraTarget = { y: this.cameraBasePosition.y, z: this.cameraBasePosition.z };
-        this.mousePosition = { x: 0, y: 0 };
+        this.mapBaseY = this.mapElevation;
+
+        this.trackCurve = null;
+        this.trackMesh = null;
+        this.trackGlow = null;
+
+        this.subwayTrain = null;
+        this.trainProgress = 0;
+        this.baseTrainSpeed = 0.00065;
+        this.trainSpeed = this.baseTrainSpeed;
+        this.lastArrivedStationIndex = null;
+
+        this.subwayStations = [];
+        this.stationLights = [];
+
+        this.cameraBasePosition = new THREE.Vector3(0, 220, 360);
+        this.cameraTarget = new THREE.Vector3(0, this.mapElevation + 20, 0);
+        this.pointer = new THREE.Vector2(0, 0);
+        this.pointerTarget = new THREE.Vector2(0, 0);
+
+        this.resizeObserver = null;
+        this.prefersReducedMotion = false;
+        this.animationActive = false;
         this.isInitialized = false;
-        
-        // Subway-themed colors
+
+        this.floatingParticles = null;
+        this.trainTrail = null;
+
         this.colors = {
             red: 0xEE352E,
             blue: 0x0039A6,
@@ -36,8 +48,7 @@ class JulesSubwayScene {
             purple: 0xB933AD,
             yellow: 0xFCCC0A
         };
-        
-        // Bind methods
+
         this.onWindowResize = this.onWindowResize.bind(this);
         this.onPointerMove = this.onPointerMove.bind(this);
         this.onPointerLeave = this.onPointerLeave.bind(this);
@@ -45,12 +56,15 @@ class JulesSubwayScene {
 
     init() {
         if (this.isInitialized) return;
-        
+
+        if (!this.setupCanvas()) {
+            return;
+        }
+
         try {
-            this.setupCanvas();
+            this.setupRenderer();
             this.setupScene();
             this.setupCamera();
-            this.setupRenderer();
             this.setupLights();
             this.createSubwayMap();
             this.createSubwayNetwork();
@@ -65,59 +79,67 @@ class JulesSubwayScene {
             this.optimizePerformance();
             this.reduceMotionForAccessibility();
             this.startAnimation();
-            
+
             this.isInitialized = true;
-            console.log('🚇 Jules AI 3D Engine initialized successfully!');
+            console.log('🚇 Jules AI 3D engine ready.');
         } catch (error) {
-            console.error('Error initializing 3D engine:', error);
+            console.error('Error initialising NYC subway scene', error);
         }
     }
-    
+
     setupCanvas() {
-        this.canvas = document.getElementById('three-canvas');
+        if (!this.canvas) {
+            this.canvas = document.getElementById('three-canvas');
+            this.stageElement = this.canvas ? this.canvas.parentElement : null;
+        }
+
         if (!this.canvas) {
             console.warn('3D canvas element not found; skipping NYC subway scene.');
-            return;
+            return false;
         }
 
         if (typeof THREE === 'undefined') {
             console.warn('Three.js is not available; cannot initialise NYC subway scene.');
-            return;
+            return false;
         }
 
-        this.prefersReducedMotion = window.matchMedia && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
-        if (this.prefersReducedMotion) {
-            this.trainSpeed = 0.012;
+        const prefersMotionQuery = window.matchMedia ? window.matchMedia('(prefers-reduced-motion: reduce)') : null;
+        if (prefersMotionQuery) {
+            this.prefersReducedMotion = prefersMotionQuery.matches;
+            const handleChange = (event) => {
+                this.prefersReducedMotion = event.matches;
+                this.updateMotionPreferences();
+            };
+            if (typeof prefersMotionQuery.addEventListener === 'function') {
+                prefersMotionQuery.addEventListener('change', handleChange);
+            } else if (typeof prefersMotionQuery.addListener === 'function') {
+                prefersMotionQuery.addListener(handleChange);
+            }
         }
+        this.updateMotionPreferences();
 
-        this.setupRenderer();
-        this.setupScene();
-        this.setupCamera();
-        this.createLights();
-        this.createMap();
-        this.createTrack();
-        this.createStations();
-        this.createTrain();
-        this.bindEvents();
+        return true;
+    }
 
-        this.animationActive = true;
-        this.renderer.setAnimationLoop(() => this.render());
-        console.log('🚇 Jules subway 3D scene ready');
+    updateMotionPreferences() {
+        this.trainSpeed = this.prefersReducedMotion ? this.baseTrainSpeed * 0.35 : this.baseTrainSpeed;
+        this.mapFloatAmplitude = this.prefersReducedMotion ? 1.6 : 4.2;
     }
-    
-    setupScene() {
-        this.scene = new THREE.Scene();
-        this.scene.fog = new THREE.Fog(0x000000, 100, 1000);
-        this.scene.add(this.mapGroup);
+
+    getCanvasSize() {
+        if (this.stageElement) {
+            const rect = this.stageElement.getBoundingClientRect();
+            return {
+                width: Math.max(rect.width, 320),
+                height: Math.max(rect.height, 240)
+            };
+        }
+        return {
+            width: this.canvas.clientWidth || window.innerWidth,
+            height: this.canvas.clientHeight || window.innerHeight * 0.7
+        };
     }
-    
-    setupCamera() {
-        const aspectRatio = window.innerWidth / window.innerHeight;
-        this.camera = new THREE.PerspectiveCamera(75, aspectRatio, 0.1, 2000);
-        this.camera.position.set(0, this.cameraBasePosition.y, this.cameraBasePosition.z);
-        this.camera.lookAt(new THREE.Vector3(0, this.mapElevation, 0));
-    }
-    
+
     setupRenderer() {
         this.renderer = new THREE.WebGLRenderer({
             canvas: this.canvas,
@@ -125,979 +147,469 @@ class JulesSubwayScene {
             alpha: true
         });
         this.renderer.setPixelRatio(Math.min(window.devicePixelRatio || 1, 2));
-
         const { width, height } = this.getCanvasSize();
         this.renderer.setSize(width, height, false);
         this.renderer.shadowMap.enabled = true;
         this.renderer.shadowMap.type = THREE.PCFSoftShadowMap;
         this.renderer.outputEncoding = THREE.sRGBEncoding;
     }
-    
-    setupLights() {
-        // Ambient light for general illumination
-        const ambientLight = new THREE.AmbientLight(0x404040, 0.3);
-        this.scene.add(ambientLight);
-        
-        // Directional light for depth
-        const directionalLight = new THREE.DirectionalLight(0xffffff, 0.8);
-        directionalLight.position.set(50, 50, 50);
-        directionalLight.castShadow = true;
-        directionalLight.shadow.mapSize.width = 2048;
-        directionalLight.shadow.mapSize.height = 2048;
-        this.scene.add(directionalLight);
-        
-        // Point lights for NYC subway ambiance
-        const colors = Object.values(this.colors);
-        for (let i = 0; i < 6; i++) {
-            const pointLight = new THREE.PointLight(colors[i], 0.5, 200);
-            pointLight.position.set(
-                Math.cos(i * Math.PI / 3) * 150,
-                Math.sin(i * Math.PI / 3) * 150,
-                Math.random() * 100 - 50
-            );
-            this.scene.add(pointLight);
-        }
-        this.renderer.setClearColor(0x010409, 0);
-    }
-
-    createSubwayMap() {
-        if (!this.renderer) return;
-
-        const loader = new THREE.TextureLoader();
-        loader.load(
-            'nyc_subway_map_optimized.jpg',
-            (texture) => {
-                texture.anisotropy = this.renderer.capabilities.getMaxAnisotropy();
-                texture.encoding = THREE.sRGBEncoding;
-
-                const mapGeometry = new THREE.PlaneGeometry(820, 520, 32, 32);
-                const mapMaterial = new THREE.MeshPhongMaterial({
-                    map: texture,
-                    transparent: true,
-                    opacity: 0.92,
-                    shininess: 40
-                });
-
-                const mapPlane = new THREE.Mesh(mapGeometry, mapMaterial);
-                mapPlane.rotation.x = -Math.PI / 2.1;
-                mapPlane.position.y = this.mapElevation;
-                mapPlane.receiveShadow = true;
-
-                const mapFrameGeometry = new THREE.EdgesGeometry(mapGeometry);
-                const mapFrameMaterial = new THREE.LineBasicMaterial({ color: 0x0f172a, transparent: true, opacity: 0.6 });
-                const mapFrame = new THREE.LineSegments(mapFrameGeometry, mapFrameMaterial);
-                mapFrame.rotation.copy(mapPlane.rotation);
-                mapFrame.position.copy(mapPlane.position);
-
-                const glowGeometry = new THREE.PlaneGeometry(840, 540);
-                const glowMaterial = new THREE.MeshBasicMaterial({
-                    color: 0x0039A6,
-                    transparent: true,
-                    opacity: 0.15,
-                    side: THREE.DoubleSide
-                });
-                const glowPlane = new THREE.Mesh(glowGeometry, glowMaterial);
-                glowPlane.rotation.copy(mapPlane.rotation);
-                glowPlane.position.copy(mapPlane.position.clone().setY(this.mapElevation - 1));
-
-                this.mapGroup.add(glowPlane);
-                this.mapGroup.add(mapPlane);
-                this.mapGroup.add(mapFrame);
-
-                // Add subtle floating animation to the entire map group
-                this.mapGroup.position.y = this.mapElevation;
-                if (typeof gsap !== 'undefined') {
-                    gsap.to(this.mapGroup.position, {
-                        y: this.mapElevation + 4,
-                        duration: 6,
-                        ease: 'sine.inOut',
-                        yoyo: true,
-                        repeat: -1
-                    });
-                }
-            },
-            undefined,
-            (error) => {
-                console.error('Failed to load NYC subway map texture', error);
-            }
-        );
-    }
-
-    createSubwayNetwork() {
-        // Create 3D subway line network
-        const elevation = this.mapElevation + 12;
-
-        this.trackPoints = [
-            new THREE.Vector3(-300, elevation, 200),
-            new THREE.Vector3(-220, elevation, 140),
-            new THREE.Vector3(-170, elevation, 60),
-            new THREE.Vector3(-120, elevation, -10),
-            new THREE.Vector3(-40, elevation, -80),
-            new THREE.Vector3(40, elevation, -140),
-            new THREE.Vector3(140, elevation, -170),
-            new THREE.Vector3(240, elevation, -120),
-            new THREE.Vector3(300, elevation, -30),
-            new THREE.Vector3(270, elevation, 90),
-            new THREE.Vector3(200, elevation, 180),
-            new THREE.Vector3(80, elevation, 230),
-            new THREE.Vector3(-60, elevation, 240),
-            new THREE.Vector3(-200, elevation, 220)
-        ];
-
-        this.trackCurve = new THREE.CatmullRomCurve3(this.trackPoints, true, 'centripetal');
-
-        const guidewayMaterial = new THREE.MeshPhongMaterial({
-            color: 0x111827,
-            emissive: 0x1f2937,
-            emissiveIntensity: 0.3,
-            transparent: true,
-            opacity: 0.85
-        });
-        const guidewayGeometry = new THREE.TubeGeometry(this.trackCurve, 400, 6, 32, true);
-        const guideway = new THREE.Mesh(guidewayGeometry, guidewayMaterial);
-        guideway.castShadow = true;
-        guideway.receiveShadow = true;
-
-        const railMaterial = new THREE.MeshStandardMaterial({
-            color: 0xd1d5db,
-            metalness: 0.6,
-            roughness: 0.3,
-            emissive: 0x4b5563,
-            emissiveIntensity: 0.1
-        });
-        const railGeometry = new THREE.TubeGeometry(this.trackCurve, 400, 2.3, 16, true);
-        const rail = new THREE.Mesh(railGeometry, railMaterial);
-        rail.castShadow = true;
-
-        const glowMaterial = new THREE.MeshBasicMaterial({
-            color: this.colors.blue,
-            transparent: true,
-            opacity: 0.25
-        });
-        const glowGeometry = new THREE.TubeGeometry(this.trackCurve, 400, 8, 16, true);
-        const glow = new THREE.Mesh(glowGeometry, glowMaterial);
-        glow.userData = { baseOpacity: glowMaterial.opacity };
-
-        this.scene.add(glow);
-        this.scene.add(guideway);
-        this.scene.add(rail);
-
-        this.subwayLines = [guideway, rail, glow];
-    }
 
     setupScene() {
         this.scene = new THREE.Scene();
-        this.scene.fog = new THREE.FogExp2(0x030712, 0.0025);
-        this.mapGroup.position.y = this.mapBaseY;
+        this.scene.fog = new THREE.Fog(0x020617, 220, 900);
         this.scene.add(this.mapGroup);
     }
 
     setupCamera() {
         const { width, height } = this.getCanvasSize();
-        const aspect = width / height;
-        this.camera = new THREE.PerspectiveCamera(42, aspect, 0.1, 2000);
+        this.camera = new THREE.PerspectiveCamera(48, width / height, 0.1, 2000);
         this.camera.position.copy(this.cameraBasePosition);
         this.camera.lookAt(this.cameraTarget);
         this.scene.add(this.camera);
     }
-    
-    createSubwayStations() {
-        if (!this.trackCurve) return;
 
-        const stationDefinitions = [
-            { name: 'BUG FIXING', color: this.colors.red, t: 0.02 },
-            { name: 'VERSION BUMPS', color: this.colors.blue, t: 0.18 },
-            { name: 'AUTOMATED TESTS', color: this.colors.green, t: 0.32 },
-            { name: 'FEATURE BUILDING', color: this.colors.orange, t: 0.48 },
-            { name: 'GITHUB INTEGRATION', color: this.colors.purple, t: 0.65 },
-            { name: 'GEMINI 2.5 POWERED', color: this.colors.yellow, t: 0.82 }
-        ];
+    setupLights() {
+        const ambient = new THREE.AmbientLight(0xffffff, 0.4);
+        this.scene.add(ambient);
 
-        this.subwayStations = [];
+        const keyLight = new THREE.DirectionalLight(0xffffff, 0.85);
+        keyLight.position.set(180, 260, 200);
+        keyLight.castShadow = true;
+        keyLight.shadow.mapSize.set(2048, 2048);
+        keyLight.shadow.camera.near = 10;
+        keyLight.shadow.camera.far = 1000;
+        this.scene.add(keyLight);
 
-        stationDefinitions.forEach((feature, index) => {
-            const basePosition = this.trackCurve.getPointAt(feature.t);
-            const elevatedPosition = basePosition.clone();
-            const platformHeight = this.mapElevation + 4;
-            const pillarHeight = elevatedPosition.y - this.mapElevation + 6;
+        const rimLight = new THREE.DirectionalLight(0x89CFF0, 0.45);
+        rimLight.position.set(-220, 200, -180);
+        this.scene.add(rimLight);
 
-            // Create station platform hovering over the map
-            const platformGeometry = new THREE.BoxGeometry(40, 4, 16);
-            const platformMaterial = new THREE.MeshPhongMaterial({
-                color: 0x1f2937,
-                emissive: feature.color,
-                emissiveIntensity: 0.2,
-                shininess: 80
-            });
-            const platform = new THREE.Mesh(platformGeometry, platformMaterial);
-            platform.position.set(basePosition.x, platformHeight, basePosition.z);
-            platform.castShadow = true;
-            platform.receiveShadow = true;
-            this.scene.add(platform);
-
-            // Create illuminated pillar connecting platform to track
-            const pillarGeometry = new THREE.CylinderGeometry(3.5, 3.5, pillarHeight, 24);
-            const pillarMaterial = new THREE.MeshPhongMaterial({
-                color: feature.color,
-                transparent: true,
-                opacity: 0.85,
-                emissive: feature.color,
-                emissiveIntensity: 0.6
-            });
-            const pillar = new THREE.Mesh(pillarGeometry, pillarMaterial);
-            pillar.position.set(basePosition.x, this.mapElevation + pillarHeight / 2, basePosition.z);
-            pillar.castShadow = true;
-            this.scene.add(pillar);
-
-            // Create glowing station marker at track level
-            const markerGeometry = new THREE.SphereGeometry(5, 32, 32);
-            const markerMaterial = new THREE.MeshBasicMaterial({
-                color: feature.color,
-                transparent: true,
-                opacity: 0.9
-            });
-            const marker = new THREE.Mesh(markerGeometry, markerMaterial);
-            marker.position.copy(elevatedPosition.clone().setY(elevatedPosition.y + 4));
-            this.scene.add(marker);
-
-            // Create station sign with NYC subway styling
-            const canvas = document.createElement('canvas');
-            const context = canvas.getContext('2d');
-            canvas.width = 256;
-            canvas.height = 64;
-
-            context.fillStyle = '#000000';
-            context.fillRect(0, 0, canvas.width, canvas.height);
-            context.fillStyle = '#FFFFFF';
-            context.font = 'bold 18px Arial';
-            context.textAlign = 'center';
-            context.fillText(feature.name, canvas.width / 2, canvas.height / 2 + 8);
-
-            const texture = new THREE.CanvasTexture(canvas);
-            const signMaterial = new THREE.MeshBasicMaterial({
-                map: texture,
-                transparent: true,
-                side: THREE.DoubleSide
-            });
-
-            const signGeometry = new THREE.PlaneGeometry(50, 14);
-            const stationSign = new THREE.Mesh(signGeometry, signMaterial);
-            stationSign.position.copy(elevatedPosition.clone().setY(elevatedPosition.y + 18));
-            stationSign.lookAt(this.camera.position.clone().setY(elevatedPosition.y + 18));
-            stationSign.userData = { followCamera: true };
-            this.scene.add(stationSign);
-
-            const stationData = {
-                name: feature.name,
-                position: {
-                    x: elevatedPosition.x,
-                    y: elevatedPosition.y,
-                    z: elevatedPosition.z
-                },
-                positionVector: elevatedPosition.clone(),
-                color: feature.color,
-                platform,
-                pillar,
-                marker,
-                sign: stationSign,
-                trackT: feature.t
-            };
-
-            this.subwayStations.push(stationData);
+        const accentColors = Object.values(this.colors);
+        accentColors.forEach((color, index) => {
+            const point = new THREE.PointLight(color, 0.6, 320, 2);
+            const angle = (index / accentColors.length) * Math.PI * 2;
+            point.position.set(Math.cos(angle) * 240, 120, Math.sin(angle) * 240);
+            this.scene.add(point);
         });
 
-        console.log('🚉 Created elevated NYC subway stations for Jules features');
+        this.renderer.setClearColor(0x010409, 0);
     }
-    
-    createSubwayTrain() {
-        // Create realistic NYC subway train
-        const trainGroup = new THREE.Group();
-        trainGroup.castShadow = true;
-        trainGroup.receiveShadow = true;
 
-        // Main train car body
-        const carGeometry = new THREE.BoxGeometry(25, 8, 60);
-        const carMaterial = new THREE.MeshPhongMaterial({
-            color: 0x2C3E50,
-            shininess: 100,
-            emissive: 0x1A252F,
-            emissiveIntensity: 0.1
-        });
-        const trainCar = new THREE.Mesh(carGeometry, carMaterial);
-        trainCar.position.y = 4;
-        trainGroup.add(trainCar);
-        
-        // Train roof
-        const roofGeometry = new THREE.BoxGeometry(26, 2, 61);
-        const roofMaterial = new THREE.MeshPhongMaterial({
-            color: 0x34495E
-        });
-        const roof = new THREE.Mesh(roofGeometry, roofMaterial);
-        roof.position.y = 9;
-        trainGroup.add(roof);
-        
-        // Train windows (front and sides)
-        const windowGeometry = new THREE.PlaneGeometry(8, 4);
-        const windowMaterial = new THREE.MeshBasicMaterial({
-            color: 0x87CEEB,
-            transparent: true,
-            opacity: 0.96
-        });
-        const basePlane = new THREE.Mesh(baseGeometry, baseMaterial);
-        basePlane.rotation.x = -Math.PI / 2;
-        basePlane.position.y = 2.5;
-        basePlane.receiveShadow = true;
-        this.mapGroup.add(basePlane);
-
-        const shadowPlane = new THREE.Mesh(
-            new THREE.PlaneGeometry(470, 320),
-            new THREE.MeshBasicMaterial({ color: 0x01060f, transparent: true, opacity: 0.3 })
-        );
-        shadowPlane.rotation.x = -Math.PI / 2;
-        shadowPlane.position.y = 0.2;
-        this.mapGroup.add(shadowPlane);
-
-        const halo = new THREE.Mesh(
-            new THREE.CircleGeometry(225, 80),
-            new THREE.MeshBasicMaterial({ color: 0x1e3a8a, transparent: true, opacity: 0.18 })
-        );
-        halo.rotation.x = -Math.PI / 2;
-        halo.position.y = 1.4;
-        this.mapGroup.add(halo);
-
-        const frame = new THREE.LineSegments(
-            new THREE.EdgesGeometry(baseGeometry),
-            new THREE.LineBasicMaterial({ color: 0x2563eb, transparent: true, opacity: 0.45 })
-        );
-        frame.rotation.x = -Math.PI / 2;
-        frame.position.y = 3.3;
-        this.mapGroup.add(frame);
-
-        const grid = new THREE.GridHelper(520, 24, 0x1d4ed8, 0x0f172a);
-        grid.rotation.y = Math.PI / 4;
-        grid.position.y = 1.2;
-        grid.material.transparent = true;
-        grid.material.opacity = 0.18;
-        this.mapGroup.add(grid);
-
+    createSubwayMap() {
         const loader = new THREE.TextureLoader();
         loader.load(
             'nyc_subway_map_optimized.jpg',
             (texture) => {
+                if (!this.renderer) return;
                 texture.anisotropy = this.renderer.capabilities.getMaxAnisotropy();
                 texture.encoding = THREE.sRGBEncoding;
-                texture.wrapS = texture.wrapT = THREE.ClampToEdgeWrapping;
 
+                const mapGeometry = new THREE.PlaneGeometry(820, 520);
                 const mapMaterial = new THREE.MeshStandardMaterial({
                     map: texture,
                     transparent: true,
-                    opacity: 0.98,
-                    roughness: 0.7,
+                    opacity: 0.96,
+                    roughness: 0.65,
                     metalness: 0.15
                 });
-                const mapMesh = new THREE.Mesh(new THREE.PlaneGeometry(420, 260, 1, 1), mapMaterial);
-                mapMesh.rotation.x = -Math.PI / 2;
-                mapMesh.position.y = 4.1;
-                mapMesh.receiveShadow = true;
-                this.mapGroup.add(mapMesh);
+                const mapPlane = new THREE.Mesh(mapGeometry, mapMaterial);
+                mapPlane.rotation.x = -Math.PI / 2;
+                mapPlane.position.y = this.mapElevation;
+                mapPlane.receiveShadow = true;
+                this.mapGroup.add(mapPlane);
+
+                const frame = new THREE.LineSegments(
+                    new THREE.EdgesGeometry(mapGeometry),
+                    new THREE.LineBasicMaterial({ color: 0x172554, transparent: true, opacity: 0.35 })
+                );
+                frame.rotation.x = -Math.PI / 2;
+                frame.position.y = this.mapElevation + 0.6;
+                this.mapGroup.add(frame);
+
+                const glowPlane = new THREE.Mesh(
+                    new THREE.PlaneGeometry(840, 540),
+                    new THREE.MeshBasicMaterial({ color: 0x0039A6, transparent: true, opacity: 0.12 })
+                );
+                glowPlane.rotation.x = -Math.PI / 2;
+                glowPlane.position.y = this.mapElevation - 3;
+                this.mapGroup.add(glowPlane);
             },
             undefined,
             (error) => console.error('Failed to load NYC subway map texture', error)
         );
     }
 
-    createTrack() {
-        const trackPoints = [
-            new THREE.Vector3(-190, 46, 110),
-            new THREE.Vector3(-130, 42, 30),
-            new THREE.Vector3(-60, 36, -40),
-            new THREE.Vector3(30, 42, -120),
-            new THREE.Vector3(170, 40, -40),
-            new THREE.Vector3(150, 38, 80),
-            new THREE.Vector3(60, 36, 130),
-            new THREE.Vector3(-120, 44, 100)
+    createSubwayNetwork() {
+        const elevation = this.mapElevation + 22;
+        const points = [
+            new THREE.Vector3(-320, elevation, 190),
+            new THREE.Vector3(-220, elevation, 120),
+            new THREE.Vector3(-160, elevation, 30),
+            new THREE.Vector3(-90, elevation, -60),
+            new THREE.Vector3(0, elevation, -150),
+            new THREE.Vector3(120, elevation, -200),
+            new THREE.Vector3(240, elevation, -120),
+            new THREE.Vector3(260, elevation, 20),
+            new THREE.Vector3(210, elevation, 160),
+            new THREE.Vector3(80, elevation, 220),
+            new THREE.Vector3(-120, elevation, 220)
         ];
 
-        this.trackCurve = new THREE.CatmullRomCurve3(trackPoints, true, 'catmullrom', 0.3);
-        const tubularSegments = 800;
-        const radius = 2.6;
-        const radialSegments = 16;
-        const closed = true;
+        this.trackCurve = new THREE.CatmullRomCurve3(points, true, 'centripetal');
 
-        const tubeGeometry = new THREE.TubeGeometry(
-            this.trackCurve,
-            tubularSegments,
-            radius,
-            radialSegments,
-            closed
-        );
+        const tubeGeometry = new THREE.TubeGeometry(this.trackCurve, 600, 4.6, 24, true);
         const tubeMaterial = new THREE.MeshStandardMaterial({
-            color: 0x3b82f6,
-            metalness: 0.65,
-            roughness: 0.25,
-            emissive: 0x1d4ed8,
-            emissiveIntensity: 0.6
+            color: 0x2563EB,
+            emissive: 0x2563EB,
+            emissiveIntensity: 0.6,
+            metalness: 0.75,
+            roughness: 0.25
         });
         this.trackMesh = new THREE.Mesh(tubeGeometry, tubeMaterial);
         this.trackMesh.castShadow = true;
         this.trackMesh.receiveShadow = true;
         this.scene.add(this.trackMesh);
 
-        const railGlowGeometry = new THREE.BufferGeometry().setFromPoints(this.trackCurve.getPoints(400));
-        const railGlowMaterial = new THREE.LineBasicMaterial({ color: 0x22d3ee, transparent: true, opacity: 0.35 });
-        this.railGlow = new THREE.LineLoop(railGlowGeometry, railGlowMaterial);
-        this.scene.add(this.railGlow);
+        const glowGeometry = new THREE.BufferGeometry().setFromPoints(this.trackCurve.getPoints(600));
+        const glowMaterial = new THREE.LineBasicMaterial({ color: 0x38BDF8, transparent: true, opacity: 0.35 });
+        this.trackGlow = new THREE.LineLoop(glowGeometry, glowMaterial);
+        this.scene.add(this.trackGlow);
+    }
 
-        const supportMaterial = new THREE.MeshStandardMaterial({
-            color: 0x111827,
-            metalness: 0.25,
-            roughness: 0.9,
-            transparent: true,
-            opacity: 0.9
+    createSubwayStations() {
+        if (!this.trackCurve) return;
+
+        const stations = [
+            { name: 'BUG FIXING', color: this.colors.red, t: 0.03 },
+            { name: 'VERSION BUMPS', color: this.colors.blue, t: 0.2 },
+            { name: 'AUTOMATED TESTS', color: this.colors.green, t: 0.36 },
+            { name: 'FEATURE BUILDING', color: this.colors.orange, t: 0.52 },
+            { name: 'GITHUB INTEGRATION', color: this.colors.purple, t: 0.68 },
+            { name: 'GEMINI 2.5 POWERED', color: this.colors.yellow, t: 0.84 }
+        ];
+
+        const textCanvas = (label) => {
+            const canvas = document.createElement('canvas');
+            canvas.width = 512;
+            canvas.height = 128;
+            const ctx = canvas.getContext('2d');
+            ctx.fillStyle = 'rgba(10, 18, 38, 0.88)';
+            ctx.fillRect(0, 0, canvas.width, canvas.height);
+            ctx.fillStyle = '#F8FAFC';
+            ctx.font = 'bold 48px "Poppins", sans-serif';
+            ctx.textAlign = 'center';
+            ctx.textBaseline = 'middle';
+            ctx.fillText(label, canvas.width / 2, canvas.height / 2);
+            return canvas;
+        };
+
+        this.subwayStations = stations.map((station) => {
+            const point = this.trackCurve.getPointAt(station.t);
+            const elevated = point.clone().setY(point.y + 8);
+
+            const marker = new THREE.Mesh(
+                new THREE.SphereGeometry(6, 24, 24),
+                new THREE.MeshStandardMaterial({
+                    color: station.color,
+                    emissive: station.color,
+                    emissiveIntensity: 0.5,
+                    metalness: 0.2,
+                    roughness: 0.4
+                })
+            );
+            marker.position.copy(elevated);
+            marker.castShadow = true;
+            this.scene.add(marker);
+
+            const pillar = new THREE.Mesh(
+                new THREE.CylinderGeometry(2.2, 2.2, elevated.y - this.mapElevation, 20),
+                new THREE.MeshStandardMaterial({ color: station.color, transparent: true, opacity: 0.38 })
+            );
+            pillar.position.set(point.x, (elevated.y + this.mapElevation) / 2, point.z);
+            this.scene.add(pillar);
+
+            const texture = new THREE.CanvasTexture(textCanvas(station.name));
+            texture.encoding = THREE.sRGBEncoding;
+            const label = new THREE.Sprite(
+                new THREE.SpriteMaterial({ map: texture, transparent: true, opacity: 0.85 })
+            );
+            label.position.copy(elevated.clone().setY(elevated.y + 18));
+            label.scale.set(120, 32, 1);
+            this.scene.add(label);
+
+            return {
+                name: station.name,
+                color: station.color,
+                t: station.t,
+                marker,
+                label,
+                pillar,
+                arrivalPulse: 0
+            };
         });
-        
-        const brandingGeometry = new THREE.PlaneGeometry(20, 5);
-        const branding = new THREE.Mesh(brandingGeometry, brandingMaterial);
-        branding.position.set(13, 4, 0);
-        branding.rotation.y = -Math.PI / 2;
-        trainGroup.add(branding);
-        
-        // Position train at starting point of the curve
-        if (this.trackCurve) {
-            const startPosition = this.trackCurve.getPointAt(0);
-            trainGroup.position.copy(startPosition);
+    }
 
+    createSubwayTrain() {
+        if (!this.trackCurve) return;
+
+        const bodyMaterial = new THREE.MeshStandardMaterial({
+            color: 0x1F2937,
+            metalness: 0.6,
+            roughness: 0.35,
+            emissive: 0x111827,
+            emissiveIntensity: 0.35
+        });
+        const carBody = new THREE.Mesh(new THREE.BoxGeometry(24, 10, 60), bodyMaterial);
+        carBody.castShadow = true;
+        carBody.receiveShadow = true;
+
+        const roof = new THREE.Mesh(
+            new THREE.CylinderGeometry(12, 12, 24, 32, 1, true, 0, Math.PI),
+            new THREE.MeshStandardMaterial({ color: 0x334155, metalness: 0.4, roughness: 0.6, side: THREE.DoubleSide })
+        );
+        roof.rotation.z = Math.PI / 2;
+        roof.position.y = 8;
+
+        const windowMaterial = new THREE.MeshStandardMaterial({
+            color: 0x0F172A,
+            roughness: 0.15,
+            metalness: 0.4,
+            transparent: true,
+            opacity: 0.75,
+            emissive: 0x38BDF8,
+            emissiveIntensity: 0.55
+        });
+        const sideWindows = new THREE.Mesh(new THREE.PlaneGeometry(40, 5), windowMaterial);
+        sideWindows.position.set(0, 5, 15);
+
+        const frontWindow = new THREE.Mesh(new THREE.PlaneGeometry(10, 6), windowMaterial.clone());
+        frontWindow.position.set(0, 5, 30.2);
+
+        const rearWindow = frontWindow.clone();
+        rearWindow.position.z = -30.2;
+        rearWindow.material = windowMaterial.clone();
+        rearWindow.material.emissive = new THREE.Color(0xF97316);
+
+        const headlights = new THREE.PointLight(0xFACC15, 1.6, 120, 2.4);
+        headlights.position.set(0, 5, 32);
+
+        const trainGroup = new THREE.Group();
+        trainGroup.add(carBody);
+        trainGroup.add(roof);
+
+        const windowsLeft = sideWindows.clone();
+        windowsLeft.position.x = -12;
+        windowsLeft.rotation.y = Math.PI / 2;
+        trainGroup.add(windowsLeft);
+
+        const windowsRight = sideWindows.clone();
+        windowsRight.position.x = 12;
+        windowsRight.rotation.y = -Math.PI / 2;
+        trainGroup.add(windowsRight);
+
+        trainGroup.add(frontWindow);
+        trainGroup.add(rearWindow);
+        trainGroup.add(headlights);
+
+        if (this.trackCurve) {
+            const start = this.trackCurve.getPointAt(0);
+            trainGroup.position.copy(start);
             const lookAhead = this.trackCurve.getPointAt(0.01);
             trainGroup.lookAt(lookAhead);
         }
 
         this.subwayTrain = trainGroup;
         this.scene.add(trainGroup);
-
-        console.log('🚆 Created Jules AI subway train');
-    }
-    
-    updateTrainMovement() {
-        if (!this.subwayTrain || !this.trackCurve) return;
-
-        this.trainProgress = (this.trainProgress + this.trainSpeed) % 1;
-
-        const currentPosition = this.trackCurve.getPointAt(this.trainProgress);
-        this.subwayTrain.position.copy(currentPosition);
-
-        const lookAhead = this.trackCurve.getPointAt((this.trainProgress + 0.01) % 1);
-        this.subwayTrain.lookAt(lookAhead);
-
-        this.checkStationArrivals(currentPosition);
     }
 
-    checkStationArrivals(position) {
-        if (!this.subwayStations.length) return;
-
-        this.subwayStations.forEach((station, index) => {
-            const stationPosition = station.positionVector.clone().setY(position.y);
-            const distance = position.distanceTo(stationPosition);
-
-            if (distance < 20 && this.lastArrivedStationIndex !== index) {
-                this.lastArrivedStationIndex = index;
-                this.createStationArrivalEffect(index);
-
-                setTimeout(() => {
-                    if (this.lastArrivedStationIndex === index) {
-                        this.lastArrivedStationIndex = null;
-                    }
-                }, 1500);
-            }
+    enhanceStationLighting() {
+        this.stationLights = this.subwayStations.map((station) => {
+            const light = new THREE.PointLight(station.color, 0.9, 180, 3);
+            light.position.copy(station.marker.position.clone().setY(station.marker.position.y + 12));
+            this.scene.add(light);
+            return light;
         });
     }
-    
-    createStationArrivalEffect(stationIndex) {
-        if (!this.subwayStations[stationIndex]) return;
 
-        const station = this.subwayStations[stationIndex];
-        const stationPosition = station.positionVector.clone();
-        
-        // Create arrival particle burst
-        const particleCount = 20;
-        const particles = [];
-        
-        for (let i = 0; i < particleCount; i++) {
-            const particle = new THREE.Mesh(
-                new THREE.SphereGeometry(0.5),
-                new THREE.MeshBasicMaterial({
-                    color: station.color,
-                    transparent: true,
-                    opacity: 0.8
-                })
-            );
-            
-            particle.position.set(
-                stationPosition.x + (Math.random() - 0.5) * 20,
-                stationPosition.y + Math.random() * 12,
-                stationPosition.z + (Math.random() - 0.5) * 20
-            );
-            support.position.set(position.x, baseHeight + height / 2 - 1.2, position.z);
-            support.castShadow = true;
-            supportGroup.add(support);
-        }
-        this.scene.add(supportGroup);
-
-        this.frenetFrames = this.trackCurve.computeFrenetFrames(tubularSegments, closed);
-    }
-
-    createStations() {
+    createTrainParticleTrail() {
         if (!this.trackCurve) return;
 
-        const stationStops = [0, 0.12, 0.24, 0.38, 0.52, 0.66, 0.82, 0.94];
-        const stationColors = [0x0ea5e9, 0x34d399, 0xf97316, 0xfacc15, 0xa855f7, 0xef4444];
-        const baseY = this.mapBaseY + 4.2;
+        const points = this.trackCurve.getPoints(200);
+        const trailGeometry = new THREE.BufferGeometry().setFromPoints(points);
+        const trailMaterial = new THREE.LineDashedMaterial({
+            color: 0x93C5FD,
+            transparent: true,
+            opacity: 0.3,
+            dashSize: 8,
+            gapSize: 4
+        });
+        this.trainTrail = new THREE.Line(trailGeometry, trailMaterial);
+        this.trainTrail.computeLineDistances();
+        this.trainTrail.material.dashOffset = 0;
+        this.scene.add(this.trainTrail);
+    }
 
-        stationStops.forEach((stop, index) => {
-            const position = this.trackCurve.getPointAt(stop % 1);
-            const color = stationColors[index % stationColors.length];
+    addTrainSounds() {
+        // Placeholder for immersive audio hooks
+        this.soundEnabled = false;
+    }
 
-            const columnHeight = Math.max(position.y - baseY, 10);
-            const column = new THREE.Mesh(
-                new THREE.CylinderGeometry(1.8, 2.4, columnHeight, 18),
-                new THREE.MeshStandardMaterial({
-                    color: 0x0f172a,
-                    metalness: 0.2,
-                    roughness: 0.85,
-                    transparent: true,
-                    opacity: 0.9
-                })
-            );
-            
-            // Position particles behind the train
-            particle.position.copy(this.subwayTrain.position);
-
-            this.scene.add(particle);
-            trailParticles.push(particle);
+    createFloatingParticles() {
+        const particleCount = 180;
+        const positions = new Float32Array(particleCount * 3);
+        for (let i = 0; i < particleCount; i++) {
+            positions[i * 3] = (Math.random() - 0.5) * 900;
+            positions[i * 3 + 1] = Math.random() * 260 + 40;
+            positions[i * 3 + 2] = (Math.random() - 0.5) * 600;
         }
 
-        // Animate trail particles to follow train
-        const updateTrail = () => {
-            if (!this.subwayTrain || !this.trackCurve) return;
-
-            trailParticles.forEach((particle, index) => {
-                // Move particles towards train position with delay
-                const tangent = this.trackCurve.getTangentAt(this.trainProgress).normalize();
-                const backwardVector = tangent.clone().multiplyScalar(-1);
-                const offsetDistance = (index + 1) * 8;
-                const targetPos = this.subwayTrain.position.clone().add(backwardVector.multiplyScalar(offsetDistance));
-                targetPos.y -= 3;
-
-                particle.position.lerp(targetPos, 0.1);
-                
-                // Add some randomness for realistic effect
-                particle.position.x += (Math.random() - 0.5) * 0.5;
-                particle.position.y += (Math.random() - 0.5) * 0.5;
-                
-                // Fade particles over time
-                particle.material.opacity = Math.max(0, 0.6 - (index * 0.1) - Math.random() * 0.1);
-            });
-            
-            requestAnimationFrame(updateTrail);
-        };
-        
-        updateTrail();
-    }
-    
-    enhanceStationLighting() {
-        this.subwayStations.forEach((station, index) => {
-            // Add dynamic lighting to stations
-            const stationLight = new THREE.PointLight(station.color, 2, 100);
-            stationLight.position.set(
-                station.positionVector.x,
-                station.positionVector.y + 25,
-                station.positionVector.z
-            );
-            
-            // Add pulsing effect
-            stationLight.userData = {
-                originalIntensity: 2,
-                pulseSpeed: 0.02 + index * 0.005
-            };
-            
-            this.scene.add(stationLight);
-            station.light = stationLight;
-            
-            // Add station platform lighting strips
-            const lightStrip = new THREE.Mesh(
-                new THREE.BoxGeometry(30, 0.5, 2),
-                new THREE.MeshBasicMaterial({
-                    color: station.color,
-                    emissive: station.color,
-                    emissiveIntensity: 0.5,
-                    metalness: 0.5,
-                    roughness: 0.35
-                })
-            );
-            lightStrip.position.set(
-                station.positionVector.x,
-                this.mapElevation + 6,
-                station.positionVector.z + 4
-            );
-            glow.rotation.x = -Math.PI / 2;
-            glow.position.set(position.x, baseY + 0.15, position.z);
-            this.scene.add(glow);
-
-            const pointLight = new THREE.PointLight(color, 1.2, 160, 2.4);
-            pointLight.position.copy(position);
-            pointLight.position.y += 14;
-            pointLight.userData.baseY = pointLight.position.y;
-            pointLight.castShadow = true;
-            this.scene.add(pointLight);
-            this.stationLights.push(pointLight);
-        });
-    }
-    
-    addTrainSounds() {
-        // Create audio context for train sounds (visual representation)
-        const trainSoundVisualizer = () => {
-            if (!this.subwayTrain) return;
-            
-            // Create sound wave visualization around train
-            const soundWaves = [];
-            const waveCount = 3;
-            
-            for (let i = 0; i < waveCount; i++) {
-                const wave = new THREE.Mesh(
-                    new THREE.RingGeometry(5 + i * 3, 6 + i * 3, 16),
-                    new THREE.MeshBasicMaterial({
-                        color: 0x00FFFF,
-                        transparent: true,
-                        opacity: 0.3 - i * 0.1,
-                        side: THREE.DoubleSide
-                    })
-                );
-                
-                wave.position.copy(this.subwayTrain.position);
-                wave.position.y += 5;
-                wave.rotation.x = Math.PI / 2;
-                
-                this.scene.add(wave);
-                soundWaves.push(wave);
-                
-                // Animate wave expansion
-                const expandWave = () => {
-                    wave.scale.multiplyScalar(1.02);
-                    wave.material.opacity *= 0.98;
-                    
-                    if (wave.material.opacity < 0.01) {
-                        this.scene.remove(wave);
-                    } else {
-                        requestAnimationFrame(expandWave);
-                    }
-                };
-                
-                setTimeout(() => expandWave(), i * 200);
-            }
-        };
-        
-        // Create sound waves periodically
-        setInterval(trainSoundVisualizer, 1000);
-    }
-    
-    setupEventListeners() {
-        window.addEventListener('resize', this.onWindowResize, false);
-        window.addEventListener('mousemove', this.onMouseMove, false);
-        
-        // Add scroll-based camera movement
-        window.addEventListener('scroll', () => {
-            const scrollPercent = window.pageYOffset / (document.documentElement.scrollHeight - window.innerHeight);
-            this.cameraTarget.z = this.cameraBasePosition.z - scrollPercent * 160;
-            this.cameraTarget.y = this.cameraBasePosition.y + scrollPercent * 80;
-            this.camera.rotation.x = -0.25 + scrollPercent * 0.35;
-        });
-        const body = new THREE.Mesh(new THREE.BoxGeometry(6.4, 6.8, 24), carBodyMaterial);
-        body.castShadow = true;
-        body.receiveShadow = true;
-        body.position.y = 6.2;
-        this.trainGroup.add(body);
-
-        const roof = new THREE.Mesh(
-            new THREE.CylinderGeometry(3.6, 3.6, 24, 24, 1, true, 0, Math.PI),
-            new THREE.MeshStandardMaterial({
-                color: 0xcbd5f5,
-                metalness: 0.7,
-                roughness: 0.42,
-                side: THREE.DoubleSide
-            })
-        );
-        roof.rotation.z = Math.PI / 2;
-        roof.position.y = 8.2;
-        this.trainGroup.add(roof);
-
-        const undercarriage = new THREE.Mesh(
-            new THREE.BoxGeometry(6.2, 1.2, 18),
-            new THREE.MeshStandardMaterial({ color: 0x0f172a, metalness: 0.4, roughness: 0.85 })
-        );
-        undercarriage.position.y = 2.5;
-        this.trainGroup.add(undercarriage);
-
-        const sideWindowMaterial = new THREE.MeshStandardMaterial({
-            color: 0x0f172a,
-            metalness: 0.4,
-            roughness: 0.25,
+        const particleGeometry = new THREE.BufferGeometry();
+        particleGeometry.setAttribute('position', new THREE.BufferAttribute(positions, 3));
+        const particleMaterial = new THREE.PointsMaterial({
+            color: 0xffffff,
+            size: 5,
             transparent: true,
-            opacity: 0.8,
-            emissive: 0x1d4ed8,
-            emissiveIntensity: 0.35,
-            side: THREE.DoubleSide
+            opacity: 0.35,
+            sizeAttenuation: true
         });
-        const sideWindowGeometry = new THREE.PlaneGeometry(16, 2.6);
-        const leftWindows = new THREE.Mesh(sideWindowGeometry, sideWindowMaterial);
-        leftWindows.position.set(-3.22, 6.2, 0);
-        leftWindows.rotation.y = Math.PI / 2;
-        this.trainGroup.add(leftWindows);
-        const rightWindows = leftWindows.clone();
-        rightWindows.position.x = 3.22;
-        rightWindows.rotation.y = -Math.PI / 2;
-        this.trainGroup.add(rightWindows);
-
-        const frontWindow = new THREE.Mesh(
-            new THREE.PlaneGeometry(5.8, 3.4),
-            new THREE.MeshStandardMaterial({
-                color: 0x111c34,
-                metalness: 0.55,
-                roughness: 0.3,
-                transparent: true,
-                opacity: 0.92,
-                emissive: 0x2563eb,
-                emissiveIntensity: 0.4
-            })
-        );
-        frontWindow.position.set(0, 6.1, 12.2);
-        this.trainGroup.add(frontWindow);
-
-        const rearWindow = frontWindow.clone();
-        rearWindow.position.z = -12.2;
-        rearWindow.material = frontWindow.material.clone();
-        rearWindow.material.emissive = new THREE.Color(0x991b1b);
-        rearWindow.material.emissiveIntensity = 0.3;
-        this.trainGroup.add(rearWindow);
-
-        const headlightMaterial = new THREE.MeshStandardMaterial({
-            color: 0xfff3b0,
-            emissive: 0xfff1a1,
-            emissiveIntensity: 1.2,
-            metalness: 0.2,
-            roughness: 0.1
-        });
-        const leftHeadlight = new THREE.Mesh(new THREE.CylinderGeometry(0.6, 0.6, 0.4, 16), headlightMaterial);
-        leftHeadlight.rotation.x = Math.PI / 2;
-        leftHeadlight.position.set(-1.2, 4.8, 12.6);
-        this.trainGroup.add(leftHeadlight);
-        const rightHeadlight = leftHeadlight.clone();
-        rightHeadlight.position.x = 1.2;
-        this.trainGroup.add(rightHeadlight);
-
-        const headlightBeamL = new THREE.SpotLight(0xfff7d6, 1.8, 80, Math.PI / 6, 0.4, 1.2);
-        headlightBeamL.position.set(-1.2, 5, 12.6);
-        headlightBeamL.target.position.set(-1.2, 4.2, 20);
-        this.trainGroup.add(headlightBeamL);
-        this.trainGroup.add(headlightBeamL.target);
-        const headlightBeamR = headlightBeamL.clone();
-        headlightBeamR.position.x = 1.2;
-        headlightBeamR.target.position.x = 1.2;
-        this.trainGroup.add(headlightBeamR);
-        this.trainGroup.add(headlightBeamR.target);
-        this.headlights.push(headlightBeamL, headlightBeamR);
-
-        const rearLightMaterial = new THREE.MeshStandardMaterial({
-            color: 0xf87171,
-            emissive: 0xb91c1c,
-            emissiveIntensity: 1.1,
-            metalness: 0.2,
-            roughness: 0.2
-        });
-        const rearLeft = new THREE.Mesh(new THREE.BoxGeometry(0.6, 0.6, 0.4), rearLightMaterial);
-        rearLeft.position.set(-1.1, 4.7, -12.4);
-        this.trainGroup.add(rearLeft);
-        const rearRight = rearLeft.clone();
-        rearRight.position.x = 1.1;
-        this.trainGroup.add(rearRight);
-
-        const interiorGlow = new THREE.PointLight(0x38bdf8, 1.2, 90, 1.8);
-        interiorGlow.position.set(0, 6.5, 0);
-        this.trainGroup.add(interiorGlow);
-
-        this.trainGroup.castShadow = true;
-        this.scene.add(this.trainGroup);
-
-        const startPosition = this.trackCurve.getPointAt(0);
-        this.trainGroup.position.copy(startPosition);
+        this.floatingParticles = new THREE.Points(particleGeometry, particleMaterial);
+        this.scene.add(this.floatingParticles);
     }
 
-    bindEvents() {
+    createInteractiveElements() {
+        this.pointer.set(0, 0);
+        this.pointerTarget.set(0, 0);
+    }
+
+    setupEventListeners() {
         window.addEventListener('resize', this.onWindowResize);
         if (this.stageElement) {
             this.stageElement.addEventListener('pointermove', this.onPointerMove);
             this.stageElement.addEventListener('pointerleave', this.onPointerLeave);
         }
+    }
 
-        if ('ResizeObserver' in window && this.stageElement) {
-            this.resizeObserver = new ResizeObserver(() => this.setRendererSize());
-            this.resizeObserver.observe(this.stageElement);
+    optimizePerformance() {
+        if (typeof ResizeObserver !== 'undefined' && (this.stageElement || this.canvas)) {
+            this.resizeObserver = new ResizeObserver(() => {
+                this.onWindowResize();
+            });
+            this.resizeObserver.observe(this.stageElement || this.canvas);
         }
+    }
+
+    reduceMotionForAccessibility() {
+        this.updateMotionPreferences();
+    }
+
+    startAnimation() {
+        if (!this.renderer) return;
+        this.clock = new THREE.Clock();
+        this.animationActive = true;
+        this.renderer.setAnimationLoop(() => this.render());
     }
 
     onWindowResize() {
-        this.setRendererSize();
-    }
-
-    onPointerMove(event) {
-        if (!this.stageElement) return;
-        const bounds = this.stageElement.getBoundingClientRect();
-        const x = (event.clientX - bounds.left) / bounds.width;
-        const y = (event.clientY - bounds.top) / bounds.height;
-        this.pointer.x = x * 2 - 1;
-        this.pointer.y = -(y * 2 - 1);
-    }
-    
-    reduceMotionForAccessibility() {
-        // Check if user prefers reduced motion
-        const prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
-        
-        if (prefersReducedMotion) {
-            // Reduce animation speed
-            this.trainProgress = 0;
-            this.trainSpeed = 0.0002;
-            
-            // Simplify particle effects
-            if (this.particleSystem) {
-                this.particleSystem.visible = false;
-            }
-            
-            // Reduce station lighting effects
-            this.subwayStations.forEach(station => {
-                if (station.light) {
-                    station.light.userData.pulseSpeed = 0.001; // Very slow pulse
-                }
-            });
-            
-            console.log('🎯 Reduced motion enabled for accessibility');
-        }
-    }
-
-    setRendererSize() {
         if (!this.renderer || !this.camera) return;
         const { width, height } = this.getCanvasSize();
         this.renderer.setSize(width, height, false);
         this.camera.aspect = width / height;
         this.camera.updateProjectionMatrix();
     }
-    
-    animate() {
-        if (!this.isInitialized) return;
-        
-        this.animationId = requestAnimationFrame(this.animate);
-        
-        const time = Date.now() * 0.001;
-        
-        // Animate subway lines and track glow
-        this.subwayLines.forEach((line, index) => {
-            if (line.userData && typeof line.userData.rotationSpeed !== 'undefined') {
-                line.rotation.z += line.userData.rotationSpeed;
-                line.position.y = Math.sin(time + index) * 10;
-            } else if (line.userData && typeof line.userData.baseOpacity !== 'undefined') {
-                const material = Array.isArray(line.material) ? line.material[0] : line.material;
-                if (material && typeof material.opacity === 'number') {
-                    const pulse = Math.sin(time * 1.5 + index) * 0.05;
-                    material.opacity = THREE.MathUtils.clamp(line.userData.baseOpacity + pulse, 0.1, 0.4);
+
+    onPointerMove(event) {
+        if (!this.stageElement) return;
+        const rect = this.stageElement.getBoundingClientRect();
+        const x = (event.clientX - rect.left) / rect.width;
+        const y = (event.clientY - rect.top) / rect.height;
+        this.pointerTarget.set(x * 2 - 1, -(y * 2 - 1));
+    }
+
+    onPointerLeave() {
+        this.pointerTarget.set(0, 0);
+    }
+
+    updateTrain(delta) {
+        if (!this.subwayTrain || !this.trackCurve) return;
+
+        this.trainProgress = (this.trainProgress + this.trainSpeed) % 1;
+        const currentPosition = this.trackCurve.getPointAt(this.trainProgress);
+        const lookAhead = this.trackCurve.getPointAt((this.trainProgress + 0.01) % 1);
+        this.subwayTrain.position.copy(currentPosition);
+        this.subwayTrain.lookAt(lookAhead);
+
+        this.checkStationArrival(currentPosition);
+
+        if (this.trainTrail) {
+            const dashOffset = (this.trainTrail.material.dashOffset || 0) - delta * 1.5;
+            this.trainTrail.material.dashOffset = dashOffset;
+        }
+    }
+
+    checkStationArrival(position) {
+        this.subwayStations.forEach((station, index) => {
+            const stationPos = this.trackCurve.getPointAt(station.t);
+            const distance = position.distanceTo(stationPos);
+            if (distance < 18) {
+                station.arrivalPulse = 1;
+                if (this.lastArrivedStationIndex !== index) {
+                    this.lastArrivedStationIndex = index;
+                    console.log(`🚉 Arrived at ${station.name}`);
                 }
             }
         });
-        
-        // Update subway train movement
-        this.updateTrainMovement();
-        
-        // Animate station lights pulsing
-        this.subwayStations.forEach(station => {
-            if (station.light) {
-                const pulse = Math.sin(time * station.light.userData.pulseSpeed) * 0.5 + 1;
-                station.light.intensity = station.light.userData.originalIntensity * pulse;
-            }
-            if (station.lightStrip) {
-                const stripPulse = Math.sin(time * 2) * 0.3 + 0.7;
-                station.lightStrip.material.emissiveIntensity = 0.5 * stripPulse;
-            }
-        });
-        
-        // Animate particles
-        if (this.particleSystem) {
-            const positions = this.particleSystem.geometry.attributes.position.array;
-            const velocities = this.particleSystem.geometry.attributes.velocity.array;
-            
-            for (let i = 0; i < positions.length; i += 3) {
-                positions[i] += velocities[i];
-                positions[i + 1] += velocities[i + 1];
-                positions[i + 2] += velocities[i + 2];
-                
-                // Wrap particles around
-                if (Math.abs(positions[i]) > 500) velocities[i] *= -1;
-                if (Math.abs(positions[i + 1]) > 500) velocities[i + 1] *= -1;
-                if (Math.abs(positions[i + 2]) > 250) velocities[i + 2] *= -1;
-            }
-            
-            this.particleSystem.geometry.attributes.position.needsUpdate = true;
-            this.particleSystem.rotation.y += 0.001;
-        }
-        
-        // Mouse-based camera movement
-        const targetX = this.mousePosition.x * 40;
-        const targetY = this.cameraTarget.y + this.mousePosition.y * 20;
+    }
 
-        this.camera.position.x += (targetX - this.camera.position.x) * 0.05;
-        this.camera.position.y += (targetY - this.camera.position.y) * 0.05;
-        this.camera.position.z += (this.cameraTarget.z - this.camera.position.z) * 0.05;
-        this.camera.lookAt(new THREE.Vector3(0, this.mapElevation, 0));
-        
-        // Animate station signs
-        this.scene.children.forEach(child => {
-            if (child.userData.floatSpeed) {
-                child.position.y = child.userData.originalY + Math.sin(time * child.userData.floatSpeed) * 20;
-                child.rotation.y += child.userData.rotationSpeed;
+    animateStations(delta) {
+        this.subwayStations.forEach((station, index) => {
+            station.arrivalPulse = Math.max(0, station.arrivalPulse - delta * 0.65);
+            const scale = 1 + station.arrivalPulse * 0.8;
+            station.marker.scale.setScalar(scale);
+            if (station.label) {
+                station.label.material.opacity = 0.75 + station.arrivalPulse * 0.2;
             }
-            if (child.userData.followCamera) {
-                child.lookAt(this.camera.position);
+            if (this.stationLights[index]) {
+                this.stationLights[index].intensity = 0.6 + station.arrivalPulse * 1.4;
             }
         });
     }
 
     animateMap(elapsed) {
-        this.mapGroup.rotation.z = Math.sin(elapsed * 0.35) * 0.05;
-        this.mapGroup.position.y = this.mapBaseY + Math.sin(elapsed * 0.45) * 1.6;
-        if (this.railGlow && this.railGlow.material) {
-            this.railGlow.material.opacity = 0.25 + Math.sin(elapsed * 2) * 0.08;
-        }
-        if (this.trackMesh && this.trackMesh.material) {
-            this.trackMesh.material.emissiveIntensity = 0.55 + Math.sin(elapsed * 1.5) * 0.12;
+        if (!this.mapGroup) return;
+        this.mapGroup.rotation.z = Math.sin(elapsed * 0.3) * 0.06;
+        this.mapGroup.position.y = this.mapBaseY + Math.sin(elapsed * 0.5) * this.mapFloatAmplitude;
+        if (this.trackGlow) {
+            this.trackGlow.material.opacity = 0.22 + Math.sin(elapsed * 1.8) * 0.08;
         }
     }
 
     animateCamera(delta) {
-        const targetX = this.cameraBasePosition.x + this.pointer.x * 55;
-        const targetY = this.cameraBasePosition.y + this.pointer.y * 28;
-        const targetZ = this.cameraBasePosition.z + this.pointer.x * 25;
+        this.pointer.lerp(this.pointerTarget, 1 - Math.exp(-delta * 5));
 
-        this.camera.position.x += (targetX - this.camera.position.x) * 0.035;
-        this.camera.position.y += (targetY - this.camera.position.y) * 0.035;
-        this.camera.position.z += (targetZ - this.camera.position.z) * 0.035;
+        const targetX = this.cameraBasePosition.x + this.pointer.x * 60;
+        const targetY = this.cameraBasePosition.y + this.pointer.y * 30;
+        const targetZ = this.cameraBasePosition.z + this.pointer.x * 30;
+
+        this.camera.position.x += (targetX - this.camera.position.x) * 0.06;
+        this.camera.position.y += (targetY - this.camera.position.y) * 0.06;
+        this.camera.position.z += (targetZ - this.camera.position.z) * 0.06;
         this.camera.lookAt(this.cameraTarget);
     }
 
     render() {
-        if (!this.animationActive) return;
+        if (!this.animationActive || !this.clock) return;
 
         const delta = this.clock.getDelta();
         const elapsed = this.clock.getElapsedTime();
 
-        this.updateTrain(delta, elapsed);
-        this.animateStations(elapsed);
+        this.updateTrain(delta);
+        this.animateStations(delta);
         this.animateMap(elapsed);
         this.animateCamera(delta);
+
+        if (this.floatingParticles) {
+            this.floatingParticles.rotation.y += delta * 0.08;
+        }
 
         this.renderer.render(this.scene, this.camera);
     }
@@ -1110,6 +622,7 @@ class JulesSubwayScene {
         }
         if (this.resizeObserver) {
             this.resizeObserver.disconnect();
+            this.resizeObserver = null;
         }
         window.removeEventListener('resize', this.onWindowResize);
         if (this.stageElement) {


### PR DESCRIPTION
## Summary
- rebuild the JulesSubwayScene three.js setup so the renderer, scene, camera, and animation loop initialise reliably
- recreate the subway map, track, train, and station visuals to bring back the live NYC subway simulation with lighting and particle accents
- add pointer-driven camera motion, reduced-motion handling, and resize observers for smoother interaction

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68fae93015b08327a71567e76fcd3b36