### PR TITLE
Ensure hero 3D scene initializes after DOM is ready

### DIFF
--- a/3d-engine.js
+++ b/3d-engine.js
@@ -657,8 +657,12 @@ class HeroParticleField {
 
 let subwayScene = null;
 let particleField = null;
+let initialized = false;
 
-document.addEventListener('DOMContentLoaded', () => {
+function initJulesHeroScene() {
+    if (initialized) return;
+    initialized = true;
+
     const canvas = document.getElementById('three-canvas');
     if (canvas && typeof THREE !== 'undefined') {
         subwayScene = new JulesSubwayScene(canvas);
@@ -677,9 +681,16 @@ document.addEventListener('DOMContentLoaded', () => {
         scene: subwayScene,
         particles: particleField
     };
-});
+}
+
+if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', initJulesHeroScene, { once: true });
+} else {
+    initJulesHeroScene();
+}
 
 window.addEventListener('beforeunload', () => {
+    initialized = false;
     if (subwayScene) {
         subwayScene.dispose();
         subwayScene = null;


### PR DESCRIPTION
## Summary
- ensure the hero subway scene initializes even when the DOM is already loaded
- guard against duplicate initialization while keeping cleanup of the scene and particles

## Testing
- pytest

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691245d2d1948327a4e10ae9830bbdf4)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved 3D scene initialization to prevent duplicate loading and initialization errors
  * Enhanced resource cleanup on page unload to prevent memory leaks and improve overall performance

<!-- end of auto-generated comment: release notes by coderabbit.ai -->