### PR TITLE
Update landing page hero background

### DIFF
--- a/style.css
+++ b/style.css
@@ -751,7 +751,7 @@ a.reddit-join-button:hover {
 /* ===== ADVANCED 3D HERO SECTION ===== */
 .hero-section {
     background: radial-gradient(circle at top, rgba(12, 20, 46, 0.85) 0%, rgba(8, 11, 25, 0.95) 45%, rgba(3, 6, 18, 0.98) 100%),
-                url('nyc_subway_map.png?v=2') center / cover fixed no-repeat;
+                url('https://upload.wikimedia.org/wikipedia/commons/thumb/5/5d/2013_NYC_subway_map.png/2048px-2013_NYC_subway_map.png') center / cover fixed no-repeat;
     padding: var(--space-20) 0;
     position: relative;
     overflow: hidden;


### PR DESCRIPTION
## Summary
- update the landing page hero background to use the provided NYC subway map image hosted on Wikimedia
- retain the existing gradient overlay so text remains legible over the new background

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69128ad8c77883279ebed479f62f2aa9)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the hero section background image.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->